### PR TITLE
reset the color after it's done executing

### DIFF
--- a/cmdfetch.lua
+++ b/cmdfetch.lua
@@ -671,3 +671,5 @@ for i = 1,math.max(#c1,#c2) do
 	m1,m2 = (" "):rep(m1),(" "):rep(m2)
 	print(m1..(c1[i] or (" "):rep(ctrim(c1[#c1]):len()))..m2..(c2[i] or ""))
 end
+
+print("\027[0m")


### PR DESCRIPTION
This was pretty annoying in PowerShell where it would turn the prompt yellow. I just added a line to fix it. I could have just complained about it in an issue but I figured this would save you some time.